### PR TITLE
Release 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A lightweight and powerful web component framework intended to remove the tediou
 🥇 Build **✅ Flexible, ✅ Extensible, and ✅ Contextful Components** with **✅ Reactive Template**, **🥳 Directives**, **✅ Data and Event Binding**
 with a **✅ Simple and Lightweight** API right in Your Browser.
 
-🚫 No Tedious State Management and DOM Manipulation! 🚫 No Robust Data Store and Context Setup! 🚫 No Verbose API. 🚫 No JSX!
+🚫 No Tedious State Management and DOM Manipulation! 🚫 No Robust Data Store and Context Setup! 🚫 No Verbose API! 🚫 No JSX! 
+🚫 No Weird HTML or Javascript Syntax!
 
 ### Example
 Declare a simple action button component
@@ -35,9 +36,9 @@ class ActionButton extends WebComponent {
       <button 
         class="my-button" 
         type="{type || 'button'}"
-        #attr.disabled="disabled"
-        #attr.autofocus="autofocus"
-        #attr.name="name"
+        attr.disabled="disabled"
+        attr.autofocus="autofocus"
+        attr.name="name"
         onclick="handleClick($event)"
         >
         <slot>{label}</slot>
@@ -59,14 +60,14 @@ class PaginatedList extends WebComponent {
   
   get template() {
     return `
-      <p #if="loading">
+      <p if="loading">
         <slot name="loading">loading...</slot>
       </p>
-      <p #if="!loading && !items.length">
+      <p if="!loading && !items.length">
         <slot name="empty">List is Empty</slot>
       </p>
-      <div #if="!loading && items.length" class="paginated-list">
-        <${this.tagName || 'div'} #repeat="items" details="{$item}">{$item}</${this.tagName || 'div'}>
+      <div if="!loading && items.length" class="paginated-list">
+        <${this.tagName || 'div'} repeat="items" details="{$item}">{$item}</${this.tagName || 'div'}>
         <action-button onclick="loadMore()">load more</action-button>
       </div>
     `;

--- a/doc/directives.md
+++ b/doc/directives.md
@@ -8,10 +8,10 @@ you cannot create custom directives.
 One thing in common for all directives is that you don't need to use the curly braces to specify data or logic.
 Their value are already understood to be information to be executed for a result.
 
-### #if
-The `#if` directive will simply add or remove a node element from the DOM.
+### if
+The `if` directive will simply add or remove a node element from the DOM.
 
-One important thing to know about the `#if` directive is that the element is always the same instance and 
+One important thing to know about the `if` directive is that the element is always the same instance and 
 it simply puts or remove it from the DOM based of something being TRUTHY or FALSY.
 
 ```js
@@ -21,9 +21,9 @@ class InputField extends WebComponent {
   get template() {
     return `
       <label class="input-field">
-        <span class="field-label" #if="label">{label}</span>
+        <span class="field-label" if="label">{label}</span>
         <input type="{type}" name="{name}" value="{value}"/>
-        <span class="error-message" #if="errorMessage">{errorMessage}</span>
+        <span class="error-message" if="errorMessage">{errorMessage}</span>
       </label>
     `
   }
@@ -35,8 +35,8 @@ InputField.register();
 Above example is an input field that will only add the label and error span elements to the DOM once their values are
 not FALSY.
 
-### #repeat
-The `#repeat` directive will repeat the DOM element based on a list-like object length or a specific number.
+### repeat
+The `repeat` directive will repeat the DOM element based on a list-like object length or a specific number.
 
 #### repeat based on number
 You can specify how many times you want the element to be repeated by simply providing a number.
@@ -47,11 +47,13 @@ Below example will repeat the `.list-item` div 10 times.
 class FlatList extends WebComponent {
   get template() {
     return `
-      <div class="list-item" #repeat="10">item</div>
+      <div class="list-item" repeat="10">item</div>
     `
   }
 }
 ```
+
+⚠️ The `repeat` directive is not meant to be used with `ref` directive. It will work with any other directives just fine.
 
 #### repeat based of data
 You can also provide iterable objects and object literal as value, and it will repeat the element based on number of
@@ -79,7 +81,7 @@ class FlatList extends WebComponent {
   
   get template() {
     return `
-      <div class="list-item" #repeat="items">item</div>
+      <div class="list-item" repeat="items">item</div>
     `
   }
 }
@@ -97,7 +99,7 @@ class FlatList extends WebComponent {
   
   get template() {
     return `
-      <div class="list-item" #repeat="items">item</div>
+      <div class="list-item" repeat="items">item</div>
     `
   }
 }
@@ -113,7 +115,7 @@ It is available whether you use a number or list-like objects.
 class FlatList extends WebComponent {
   get template() {
     return `
-      <div class="list-item" #repeat="10">{$item}</div>
+      <div class="list-item" repeat="10">{$item}</div>
     `
   }
 }
@@ -127,7 +129,7 @@ class FlatList extends WebComponent {
   
   get template() {
     return `
-      <div class="list-item" #repeat="items">{$item}</div>
+      <div class="list-item" repeat="items">{$item}</div>
     `
   }
 }
@@ -141,7 +143,7 @@ be an index, number starting from 0. For Map and Object literal, the key will be
 class FlatList extends WebComponent {
   get template() {
     return `
-      <div class="list-item item-{$key}" #repeat="10">{$item}</div>
+      <div class="list-item item-{$key}" repeat="10">{$item}</div>
     `
   }
 }
@@ -157,14 +159,177 @@ class FlatList extends WebComponent {
   
   get template() {
     return `
-      <div class="list-item {$key}" #repeat="items">{key} item: {$item}</div>
+      <div class="list-item {$key}" repeat="items">{key} item: {$item}</div>
     `
   }
 }
 ```
 
-### #ref
+### ref
+The `ref` directive allows you to grab a reference to a DOM element. Its value must be the name of the property you want
+to assign the reference to.
 
-### #attr
+You can access all the dom element references by using the `$refs` property in the class;
+
+```js
+class InputField extends WebComponent {
+  static observedAttributes = ['label', 'value', 'name', 'type', 'error-message'];
+  
+  onMount() {
+    // the $refs object will contain all the DOM references
+    this.$refs.input.focus();
+  }
+  
+  get template() {
+    return `
+      <label class="input-field">
+        <input ref="input" type="{type}" name="{name}" value="{value}"/>
+      </label>
+    `
+  }
+}
+
+InputField.register();
+```
+
+⚠️ You can only use the `ref` directive once per element ,and it will not work if you use it with a `repeat` directive.
+
+
+### attr
+The `attr` directive allows you to set an attribute on the DOM element based on TRUTHY or FALSEY value.
+
+It uses the dot notation to separate the attribute name and the value and its value can have two parts
+depending on the attribute you are setting;
+
+There are 4 special attributes with special handling: class, style, data and boolean. Everything else will follow the following format:
+
+    attr.[attribute-name]="[attribute value], [condition]"
+
+    Note: The [attribute value] may contain data binding curly braces for data binding but for the [condition] the curly
+    braces are not necessary.
+
+#### Boolean Attributes
+There are certain attributes in HTML that are considered [boolean attributes](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes). 
+They do not require a value, but if you set them to true, they will be set to the attribute name.
+
+The below example will only set the `disabled` attribute on the button if the `disabled` property is truthy.
+
+```js
+class ActionButton extends WebComponent {
+  static observedAttributes = ['disabled', 'type'];
+  
+  get template() {
+    return `
+      <button type="{type}" attr.disabled="disabled"></button>
+    `
+  }
+}
+
+ActionButton.register();
+```
+
+#### Style Attribute
+There are two ways you can use the `attr` directive to set style attributes. You can use it for a specific style
+property...
+
+```js
+class ActionButton extends WebComponent {
+  static observedAttributes = ['sub-type', 'type'];
+  
+  get template() {
+    return `
+      <button type="{type}" attr.style.font-weigth="bold, subType === 'primary'"></button>
+    `
+  }
+}
+
+ActionButton.register();
+```
+with the format of:
+
+    attr.style.[property-name]="[value], [condition]"
+
+...or you can use it to set a style CSS string;
+
+```js
+class ActionButton extends WebComponent {
+  static observedAttributes = ['sub-type', 'type'];
+  
+  get template() {
+    return `
+      <button type="{type}" attr.style="background: orange; color: black;, subType === 'cta'"></button>
+    `
+  }
+}
+
+ActionButton.register();
+```
+with the format of:
+
+    attr.style="[CSS string], [condition]"
+
+#### Class Attribute
+The `attr` directive can also be used to set class attributes, and it follows the same concept as the style attribute.
+
+You can use it for a specific class...
+
+```js
+class ActionButton extends WebComponent {
+  static observedAttributes = ['sub-type', 'type'];
+  
+  get template() {
+    return `
+      <button type="{type}" attr.class.primary="subType === 'primary'"></button>
+    `
+  }
+}
+
+ActionButton.register();
+```
+with the format of:
+
+    attr.class.[class-name]="[condition]"
+
+...or you can use it to set a style CSS string;
+
+```js
+class ActionButton extends WebComponent {
+  static observedAttributes = ['sub-type', 'type'];
+  
+  get template() {
+    return `
+      <button type="{type}" attr.class="primary-{subType}, subType === 'cta'"></button>
+    `
+  }
+}
+
+ActionButton.register();
+```
+with the format of:
+
+    attr.class="[class names], [condition]"
+
+#### Data Attribute
+The data attribute is another special attribute that only follows a single format:
+
+You can only use it for a specific data name
+
+```js
+class ActionButton extends WebComponent {
+  static observedAttributes = ['sub-type', 'type'];
+  
+  get template() {
+    return `
+      <button type="{type}" attr.data.special-button="{subType}, subType !== 'default'"></button>
+    `
+  }
+}
+
+ActionButton.register();
+```
+with the format of:
+
+    attr.data.[data-name]="[value], [condition]"
+
 
 #### Recommended next: [LiveCycles](https://github.com/beforesemicolon/web-component/blob/master/doc/livecycles.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beforesemicolon/web-component",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Web Component Client Framework",
   "main": "dist/index.js",
   "scripts": {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -17,7 +17,7 @@ export declare global {
 			value: string;
 			executables: Array<Executable>;
 		}>;
-		hashedAttrs: Array<HashedAttribute>;
+		directives: Array<Directive>;
 		property: null | {
 			name: string;
 			value: string;
@@ -25,9 +25,9 @@ export declare global {
 		};
 	}
 
-	export type HashedAttribute = '#attr' | '#ref' | '#repeat' | '#if';
+	export type Directive = 'attr' | 'ref' | 'repeat' | 'if';
 
-	export interface HashedAttributeValue {
+	export interface DirectiveValue {
 		value: string;
 		prop: string;
 		placeholderNode?: Comment;
@@ -73,11 +73,11 @@ export declare global {
 		onError: (error: ErrorEvent) => void;
 		forceUpdate: () => void;
 
-		#ref?: HashedAttribute;
-		#repeat?: HashedAttribute;
-		#repeat_id?: HashedAttribute;
-		#if?: HashedAttribute;
-		#attr?: HashedAttribute;
+		ref?: Directive;
+		repeat?: Directive;
+		repeat_id?: Directive;
+		if?: Directive;
+		attr?: Directive;
 
 		[key: string]: any;
 	}

--- a/src/utils/get-component-node-event-listener.spec.ts
+++ b/src/utils/get-component-node-event-listener.spec.ts
@@ -14,7 +14,7 @@ describe('getComponentNodeEventListener', () => {
 		btn.onClick = jest.fn();
 		btn.clicked = jest.fn();
 
-		let handler = getComponentNodeEventListener(btn as any, 'click', 'clicked("sample", 300)');
+		let handler = getComponentNodeEventListener(btn as any, 'click', 'clicked("sample", 300)') as any;
 
 		expect(handler.toString()).toEqual('(event) => func.call(component, event)')
 
@@ -36,20 +36,14 @@ describe('getComponentNodeEventListener', () => {
 		jest.resetAllMocks();
 	});
 
-	it('should throw error if function does not exist or is not a function', () => {
-		expect(() => getComponentNodeEventListener(btn as any, 'click', 'onTest()'))
-			.toThrowError('Button: "onTest" is not a function')
-		expect(() => getComponentNodeEventListener(btn as any, 'click', 'sampler()'))
-			.toThrowError('Button: "sampler" is not a function')
-	});
-
-	it('should throw error it handler is not supported', () => {
-		expect(() => getComponentNodeEventListener(btn as any, 'click', 'onClick'))
-			.toThrowError('Button: Invalid event handler for "click" >>> "onClick".')
+	it('should return null if function does not exist or is not a function', () => {
+		expect(getComponentNodeEventListener(btn as any, 'click', 'onTest()')).toBeNull()
+		expect(getComponentNodeEventListener(btn as any, 'click', 'sampler()')).toBeNull()
+		expect(getComponentNodeEventListener(btn as any, 'click', 'onClick')).toBeNull()
 	});
 
 	it('should get listener with executables', () => {
-		let handler = getComponentNodeEventListener(btn as any, 'click', '{this.sampler = [2, 4, 6]}');
+		let handler = getComponentNodeEventListener(btn as any, 'click', '{this.sampler = [2, 4, 6]}') as any;
 
 		expect(handler.toString()).toEqual('(event) => fn.call(component, event, ...props.map(prop => component[prop]))');
 

--- a/src/utils/get-component-node-event-listener.ts
+++ b/src/utils/get-component-node-event-listener.ts
@@ -19,4 +19,6 @@ export function getComponentNodeEventListener(component: WebComponent, name: str
 			}
 		}
 	}
+
+	return null;
 }

--- a/src/utils/parse-node-directive.spec.ts
+++ b/src/utils/parse-node-directive.spec.ts
@@ -1,0 +1,33 @@
+import {parseNodeDirective} from "./parse-node-directive";
+
+describe('parseNodeDirective', () => {
+	it('should set directive details on the node and remove the attribute ', () => {
+		const div = document.createElement('div');
+		div.innerHTML = `<div if="val > 100" attr.class="unique, true" attr.data-sample="cool, true"></div>`;
+		const node: any = div.children[0];
+		const directives = new Set();
+
+		for (let x of [...node.attributes]) {
+			directives.add(parseNodeDirective(node, x.name, x.value));
+		}
+
+		expect(directives).toEqual(new Set(["if", "attr"]));
+		expect(node.outerHTML).toBe('<div></div>');
+		expect(node.if).toEqual([
+			{
+				"prop": null,
+				"value": "val > 100"
+			}
+		]);
+		expect(node.attr).toEqual([
+			{
+				"prop": "class",
+				"value": "unique, true"
+			},
+			{
+				"prop": "data-sample",
+				"value": "cool, true"
+			}
+		]);
+	});
+});

--- a/src/utils/parse-node-directive.ts
+++ b/src/utils/parse-node-directive.ts
@@ -1,0 +1,21 @@
+export function parseNodeDirective(node: Element, name: string, value: string): Directive {
+	const ogName = name;
+	const dot = name.indexOf('.');
+	let prop = null;
+
+	if (dot >= 0) {
+		prop = name.slice(dot + 1);
+		name = name.slice(0, dot);
+	}
+
+	// @ts-ignore
+	if (node[name] === undefined) {
+		(node as any)[name] = [{value, prop}]
+	} else {
+		(node as any)[name].push({value, prop})
+	}
+
+	node.removeAttribute(ogName);
+
+	return name as Directive;
+}

--- a/src/utils/parse.spec.ts
+++ b/src/utils/parse.spec.ts
@@ -213,26 +213,4 @@ describe('parse', () => {
     });
   });
 
-  it('should handle hashed attribute', () => {
-    const root = parse('<p #if="true"></p><button #attr.disabled="true"></button>');
-    const p = root.children[0];
-    const btn = root.children[1];
-
-    expect(stringifyNode(p)).toBe('<p></p>');
-    // @ts-ignore
-    expect(p['#if']).toEqual([
-      {
-        "prop": null,
-        "value": "true"
-      }
-    ]);
-    // @ts-ignore
-    expect(btn['#attr']).toEqual([
-      {
-        "prop": "disabled",
-        "value": "true"
-      }
-    ]);
-  });
-
 })

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -1,7 +1,7 @@
 import selfClosingTags from './self-closing-tags.json';
 
 export function parse(markup: string) {
-	const tagCommentPattern = /<!--([^]*?)-->|<(\/|!)?([a-z][\w-.:]*)((?:\s+#?[a-z][\w-.:]*(?:\s*=\s*(?:"[^"]*"|'[^']*'))?)+\s*|\s*)(\/?)>/ig;
+	const tagCommentPattern = /<!--([^]*?)-->|<(\/|!)?([a-z][\w-.:]*)((?:\s+[a-z][\w-.:]*(?:\s*=\s*(?:"[^"]*"|'[^']*'))?)+\s*|\s*)(\/?)>/ig;
 	const root = document.createDocumentFragment();
 	const stack: Array<DocumentFragment | HTMLElement> = [root];
 	let match: RegExpExecArray | null = null;
@@ -61,7 +61,7 @@ export function parse(markup: string) {
 }
 
 function setAttributes(node: HTMLElement, attributes: string) {
-	const attrPattern = /(#?[a-z][\w-.:]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+)))?/ig;
+	const attrPattern = /([a-z][\w-.:]*)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+)))?/ig;
 	let match: RegExpExecArray | null = null;
 
 	while ((match = attrPattern.exec(attributes))) {
@@ -70,25 +70,6 @@ function setAttributes(node: HTMLElement, attributes: string) {
 			new RegExp(`^${match[1]}\\s*=`).test(match[0]) ? '' : null
 		)
 
-		if (name.startsWith('#')) {
-			const dot = name.indexOf('.');
-			let prop = null;
-
-			if (dot >= 0) {
-				prop = name.slice(dot + 1);
-				name = name.slice(0, dot);
-			}
-
-			// this is a special handler for custom attributes since its syntax is not allowed
-			// for HTML attributes allowing this parser to work with normal DOM elements
-			// @ts-ignore
-			if (node[name] === undefined) {
-				(node as any)[name] = [{value, prop}]
-			} else {
-				(node as any)[name].push({value, prop})
-			}
-		} else {
-			node.setAttribute(name, value ?? '');
-		}
+		node.setAttribute(name, value ?? '');
 	}
 }

--- a/src/web-component.spec.ts
+++ b/src/web-component.spec.ts
@@ -612,11 +612,11 @@ describe('WebComponent', () => {
 	});
 
 	describe('directives', () => {
-		describe('#ref', () => {
+		describe('ref', () => {
 			it('should set ref attribute', () => {
                 class RefA extends WebComponent {
                     get template() {
-                        return '<div #ref="myRef"></div>'
+                        return '<div ref="myRef"></div>'
                     }
                 }
 
@@ -632,7 +632,7 @@ describe('WebComponent', () => {
 			it('should allow to be used in template', () => {
 				class RefB extends WebComponent {
 					get template() {
-						return '<div #ref="myRef">{$refs.myRef.nodeName}</div>{$refs.myRef.childNodes.length}'
+						return '<div ref="myRef">{$refs.myRef.nodeName}</div>{$refs.myRef.childNodes.length}'
 					}
 				}
 
@@ -648,7 +648,7 @@ describe('WebComponent', () => {
 			it('should crashed if used before create in the template', (done) => {
 				class RefC extends WebComponent {
 					get template() {
-						return '{$refs.myRef.nodeName}<div #ref="myRef"></div>'
+						return '{$refs.myRef.nodeName}<div ref="myRef"></div>'
 					}
 
 					onError(error: ErrorEvent) {
@@ -664,14 +664,15 @@ describe('WebComponent', () => {
 			});
 		});
 
-		describe('should handle #attr', () => {
+		describe('should handle attr', () => {
 			it('should handle class attribute', () => {
 				class AttrA extends WebComponent {
 					check1 = true;
 					check2 = true;
+					val = 'attr'
 
 					get template() {
-						return '<div #attr.class.test="check1" #attr.class="sample, check2">'
+						return '<div attr.class.test="check1" attr.class="sample-{val}, check2">'
 					}
 				}
 
@@ -680,24 +681,26 @@ describe('WebComponent', () => {
 
 				document.body.appendChild(s);
 
-				expect(s.root?.innerHTML).toBe('<div class="test sample"></div>')
+				expect(s.root?.innerHTML).toBe('<div class="test sample-attr"></div>')
 
 				s.check1 = false;
 
-				expect(s.root?.innerHTML).toBe('<div class="sample"></div>')
+				expect(s.root?.innerHTML).toBe('<div class="sample-attr"></div>')
 
 				s.check1 = true;
 
-				expect(s.root?.innerHTML).toBe('<div class="sample test"></div>')
+				expect(s.root?.innerHTML).toBe('<div class="sample-attr test"></div>')
 			});
 
 			it('should handle style attribute', () => {
 				class AttrB extends WebComponent {
 					check1 = true;
 					check2 = true;
+					errorColor = 'red';
+					textColor = 'white';
 
 					get template() {
-						return '<div #attr.style="color: white, check1" #attr.style.background-color="red, check2">'
+						return '<div attr.style="color: {textColor}, check1" attr.style.background-color="{errorColor}, check2">'
 					}
 				}
 
@@ -721,9 +724,10 @@ describe('WebComponent', () => {
 				class AttrC extends WebComponent {
 					check1 = true;
 					check2 = true;
+					status = 'good';
 
 					get template() {
-						return '<div #attr.data.sampleTest="good, check1" #attr.data.dashed-sample="great, check2">'
+						return '<div attr.data.sample-test="{status}, check1" attr.data.dashed-sample="great, check2">'
 					}
 				}
 
@@ -749,7 +753,7 @@ describe('WebComponent', () => {
 					check2 = true;
 
 					get template() {
-						return '<button #attr.disabled="check1" #attr.hidden="check2"></button>'
+						return '<button attr.disabled="check1" attr.hidden="check2"></button>'
 					}
 				}
 
@@ -775,7 +779,7 @@ describe('WebComponent', () => {
 					check2 = true;
 
 					get template() {
-						return '<button #attr.autocomplete="check1" #attr.autofocus="check2" #attr.name="sample, check2"></button>'
+						return '<button attr.autocomplete="check1" attr.autofocus="check2" attr.name="sample, check2"></button>'
 					}
 				}
 
@@ -796,13 +800,13 @@ describe('WebComponent', () => {
 			});
 		});
 
-		describe('should handle #if', () => {
+		describe('should handle if', () => {
 			it('should render element if truthy', () => {
 				class IfA extends WebComponent {
 					check = true;
 
 					get template() {
-						return '<button #if="check">click me</button>'
+						return '<button if="check">click me</button>'
 					}
 				}
 
@@ -815,21 +819,43 @@ describe('WebComponent', () => {
 
 				s.check = false;
 
-				expect(s.root?.innerHTML).toBe('<!--#if: check-->');
+				expect(s.root?.innerHTML).toBe('<!--if: check-->');
 
 				s.check = true;
 
 				expect(s.root?.innerHTML).toBe('<button>click me</button>');
 			});
+
+			it('should handle nested if', () => {
+				class IfB extends WebComponent {
+					check = true;
+					icon = '';
+
+					get template() {
+						return '<button if="check">click me <span if="icon">{icon}</span></button>'
+					}
+				}
+
+				IfB.register();
+				const s = new IfB();
+
+				document.body.appendChild(s);
+
+				expect(s.root?.innerHTML).toBe('<button>click me <!--if: icon--></button>');
+
+				s.icon = 'star';
+
+				expect(s.root?.innerHTML).toBe('<button>click me <span>star</span></button>');
+			});
 		});
 
-		describe('should handle #repeat', () => {
+		describe('should handle repeat', () => {
 			it('should repeat element based on number', () => {
 				class RepeatA extends WebComponent {
 					count: any = 3;
 
 					get template() {
-						return '<li #repeat="count" class="item-{$key}">item {$item}</li>'
+						return '<li repeat="count" class="item-{$key}">item {$item}</li>'
 					}
 				}
 
@@ -838,31 +864,37 @@ describe('WebComponent', () => {
 
 				document.body.appendChild(s);
 
-				expect(s.root?.innerHTML).toBe('<!--#repeat: count--><li class="item-0">item 1</li><li class="item-1">item 2</li><li class="item-2">item 3</li>');
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-0">item 1</li><li class="item-1">item 2</li><li class="item-2">item 3</li>');
 
 				s.count = 1;
 
-				expect(s.root?.innerHTML).toBe('<!--#repeat: count--><li class="item-0">item 1</li>');
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-0">item 1</li>');
 
 				s.count = Array.from({length: 3}, (_, i) => i+1);
 
-				expect(s.root?.innerHTML).toBe('<!--#repeat: count--><li class="item-0">item 1</li><li class="item-1">item 2</li><li class="item-2">item 3</li>');
+				s.count = 1;
+
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-0">item 1</li>');
+
+				s.count = Array.from({length: 3}, (_, i) => i+1);
+
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-0">item 1</li><li class="item-1">item 2</li><li class="item-2">item 3</li>');
 
 				s.count = new Set([2, 4, 6]);
 
-				expect(s.root?.innerHTML).toBe('<!--#repeat: count--><li class="item-0">item 2</li><li class="item-1">item 4</li><li class="item-2">item 6</li>');
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-0">item 2</li><li class="item-1">item 4</li><li class="item-2">item 6</li>');
 
 				s.count = new Map([['one', 1], ['two', 2], ['three', 3]]);
 
-				expect(s.root?.innerHTML).toBe('<!--#repeat: count--><li class="item-one">item 1</li><li class="item-two">item 2</li><li class="item-three">item 3</li>');
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-one">item 1</li><li class="item-two">item 2</li><li class="item-three">item 3</li>');
 
 				s.count = {one: 100, two: 200, three: 300};
 
-				expect(s.root?.innerHTML).toBe('<!--#repeat: count--><li class="item-one">item 100</li><li class="item-two">item 200</li><li class="item-three">item 300</li>');
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-one">item 100</li><li class="item-two">item 200</li><li class="item-three">item 300</li>');
 
 				s.count = 'two';
 
-				expect(s.root?.innerHTML).toBe('<!--#repeat: count--><li class="item-0">item t</li><li class="item-1">item w</li><li class="item-2">item o</li>');
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-0">item t</li><li class="item-1">item w</li><li class="item-2">item o</li>');
 
 				s.count = {
 					*[Symbol.iterator]() {
@@ -872,19 +904,45 @@ describe('WebComponent', () => {
 					}
 				}
 
-				expect(s.root?.innerHTML).toBe('<!--#repeat: count--><li class="item-0">item 500</li><li class="item-1">item 250</li><li class="item-2">item 50</li>');
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-0">item 500</li><li class="item-1">item 250</li><li class="item-2">item 50</li>');
 
+			});
+
+			it('should handle nested repeats', () => {
+				class RepeatB extends WebComponent {
+					count: any = 2;
+					innerCount: any = 2;
+
+					get template() {
+						return '<li repeat="count" class="item-{$key}">item {$item} <span repeat="innerCount">{$item}</span></li>'
+					}
+				}
+
+				RepeatB.register();
+				const s = new RepeatB();
+
+				document.body.appendChild(s);
+
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-0">item 1 <!--repeat: innerCount--><span>1</span><span>2</span></li><li class="item-1">item 2 <!--repeat: innerCount--><span>1</span><span>2</span></li>');
+
+				s.count = 1;
+
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-0">item 1 <!--repeat: innerCount--><span>1</span><span>2</span></li>');
+
+				s.innerCount = 3;
+
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-0">item 1 <!--repeat: innerCount--><span>1</span><span>2</span><span>3</span></li>');
 			});
 		});
 
 		describe('should allow mix of hashed attributes', () => {
-			it('#if and #repeat', () => {
+			it('if and repeat', () => {
 				class ComboA extends WebComponent {
 					condition = false;
 					count = 3;
 
 					get template() {
-						return '<li #repeat="count" #if="condition" class="item-{$key}">item {$item}</li>'
+						return '<li repeat="count" if="condition" class="item-{$key}">item {$item}</li>'
 					}
 				}
 
@@ -893,31 +951,31 @@ describe('WebComponent', () => {
 
 				document.body.appendChild(s);
 
-				expect(s.root?.innerHTML).toBe('<!--#if: condition-->');
+				expect(s.root?.innerHTML).toBe('<!--if: condition-->');
 
 				s.condition = true;
 
-				expect(s.root?.innerHTML).toBe('<!--#repeat: count--><li class="item-0">item 1</li><li class="item-1">item 2</li><li class="item-2">item 3</li>');
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-0">item 1</li><li class="item-1">item 2</li><li class="item-2">item 3</li>');
 
 				s.condition = false;
 
-				expect(s.root?.innerHTML).toBe('<!--#if: condition-->');
+				expect(s.root?.innerHTML).toBe('<!--if: condition-->');
 
 				s.count = 2;
 
-				expect(s.root?.innerHTML).toBe('<!--#if: condition-->');
+				expect(s.root?.innerHTML).toBe('<!--if: condition-->');
 
 				s.condition = true;
 
-				expect(s.root?.innerHTML).toBe('<!--#repeat: count--><li class="item-0">item 1</li><li class="item-1">item 2</li>');
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li class="item-0">item 1</li><li class="item-1">item 2</li>');
 			});
 
-			it('#if and #ref', () => {
+			it('if and ref', () => {
 				class ComboB extends WebComponent {
 					condition = false;
 
 					get template() {
-						return '<li #if="condition" class="item" #ref="item">my item</li>'
+						return '<li if="condition" class="item" ref="item">my item</li>'
 					}
 				}
 
@@ -928,7 +986,7 @@ describe('WebComponent', () => {
 
 				const initItemRef = s.$refs.item;
 
-				expect(s.root?.innerHTML).toBe('<!--#if: condition-->');
+				expect(s.root?.innerHTML).toBe('<!--if: condition-->');
 				expect(initItemRef).toBeDefined();
 
 				s.condition = true;
@@ -937,12 +995,12 @@ describe('WebComponent', () => {
 				expect(initItemRef === s.$refs.item).toBeTruthy();
 			});
 
-			it('#if and #attr', () => {
+			it('if and attr', () => {
 				class ComboC extends WebComponent {
 					condition = false;
 
 					get template() {
-						return '<li #if="condition" #attr.class.item="condition" #attr.id="unique, true">my item</li>'
+						return '<li if="condition" attr.class.item="condition" attr.id="unique, true">my item</li>'
 					}
 				}
 
@@ -951,19 +1009,19 @@ describe('WebComponent', () => {
 
 				document.body.appendChild(s);
 
-				expect(s.root?.innerHTML).toBe('<!--#if: condition-->');
+				expect(s.root?.innerHTML).toBe('<!--if: condition-->');
 
 				s.condition = true;
 
 				expect(s.root?.innerHTML).toBe('<li class="item" id="unique">my item</li>');
 			});
 
-			it('#repeat and #ref', () => {
+			it('repeat and ref', () => {
 				class ComboD extends WebComponent {
 					count = 2;
 
 					get template() {
-						return '<li #repeat="count" #ref="sample">{$item}-{$key}</li>'
+						return '<li repeat="count" ref="sample">{$item}-{$key}</li>'
 					}
 				}
 
@@ -972,16 +1030,16 @@ describe('WebComponent', () => {
 
 				document.body.appendChild(s);
 
-				expect(s.root?.innerHTML).toBe('<!--#repeat: count--><li>1-0</li><li>2-1</li>');
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li>1-0</li><li>2-1</li>');
 				expect(s.$refs.sample).toBeUndefined();
 			});
 
-			it('#repeat and #attr', () => {
+			it('repeat and attr', () => {
 				class ComboE extends WebComponent {
 					count = 2;
 
 					get template() {
-						return '<li #repeat="count" #attr.data.test="sample, $key">{$item}-{$key}</li>'
+						return '<li repeat="count" attr.data.test="sample, $key">{$item}-{$key}</li>'
 					}
 				}
 
@@ -990,13 +1048,13 @@ describe('WebComponent', () => {
 
 				document.body.appendChild(s);
 
-				expect(s.root?.innerHTML).toBe('<!--#repeat: count--><li>1-0</li><li data-test="sample">2-1</li>');
+				expect(s.root?.innerHTML).toBe('<!--repeat: count--><li>1-0</li><li data-test="sample">2-1</li>');
 			});
 
-			it('#attr and #ref', () => {
+			it('attr and ref', () => {
 				class ComboF extends WebComponent {
 					get template() {
-						return '<li #ref="item" #attr.data.test="sample, true">my item</li>'
+						return '<li ref="item" attr.data.test="sample, true">my item</li>'
 					}
 				}
 


### PR DESCRIPTION
- remove hashed attribute logic from the HTML parser
- directives do not need # in front to work
- supports nested [repeat directive](https://github.com/beforesemicolon/web-component/blob/master/doc/directives.md#repeat)
- documentation for directives completed
- support data binding on directives values