### PR TITLE
Release 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ require('esbuild').build({
 ### Documentation
 
 - [WebComponent](https://github.com/beforesemicolon/web-component/blob/master/doc/WebComponent.md)
+- [ContextProviderComponent](https://github.com/beforesemicolon/web-component/blob/master/doc/ContextProviderComponent.md)
 - [Configurations](https://github.com/beforesemicolon/web-component/blob/master/doc/configurations.md)
 - [Template](https://github.com/beforesemicolon/web-component/blob/master/doc/template.md)
 - [Events](https://github.com/beforesemicolon/web-component/blob/master/doc/events.md)

--- a/doc/ContextProviderComponent.md
+++ b/doc/ContextProviderComponent.md
@@ -1,0 +1,208 @@
+## ContextProviderComponent
+
+The ContextProviderComponent class is a
+special [WebComponent](https://github.com/beforesemicolon/web-component/blob/master/doc/WebComponent.md)
+in a sense that it allows you to define the template right in your HTML file with it serving as the data provider for
+your template.
+
+```js
+// in the browser
+const {ContextProviderComponent} = window;
+
+// in node
+import {ContextProviderComponent} from "@beforesemicolon/web-component";
+```
+
+### Template
+
+By default, the template is a single slot tag which means you don't need to define the component template inside the
+class.
+
+Define your data in the class...
+
+```js
+// todo-app.js
+
+class TodoApp extends ContextProviderComponent {
+  app = {
+    title: "Todo App",
+    description: "My super cool todo app",
+  }
+}
+
+TodoApp.register();
+```
+
+...then set the content right in the HTML file.
+
+```html
+<!-- index.html-->
+
+<todo-app>
+	<h1>{app.title}</h1>
+	<p>{app.description</p>
+</todo-app>
+```
+
+### The slot tag
+
+What really makes the ContextProviderComponent special is how it handles the `slot` tag. It has a custom slot handler that gives
+it its superpowers. This means that no matter the component mode, the slot tag will be handled the same way.
+
+The template is a single slot tag, but you can also define your own template with slots where you wish. The only thing
+you need to keep in mind is that the slot is handled differently.
+
+The example below renders the title and description inside and lets the rest of the app to be defined in the HTML file.
+
+```js
+// todo-app.js
+
+class TodoApp extends ContextProviderComponent {
+  app = {
+    title: "Todo App",
+    description: "My super cool todo app",
+    todos: []
+  }
+  
+  onMount() {
+    fetch('http://localhost:3000/api/todo')
+      .then(res => res.json())
+      .then(res => {
+        this.app.todos = res.data;
+      })
+  }
+  
+  openTodo() {
+    // handle opening todo
+  }
+  
+  get template() {
+    return `
+      <h1>{app.title}</h1>
+      <p>{app.description</p>
+      <slot></slot>
+    `;
+  }
+}
+
+TodoApp.register();
+```
+
+You can render the `todo-item` tag inside the `todo-app` tag and it will be placed where the slot tag is defined using
+the [repeat directive](https://github.com/beforesemicolon/web-component/blob/master/doc/directives.md#repeat) to repeat
+for every todo item.
+
+```html
+<!-- index.html-->
+
+<todo-app>
+	<todo-item
+            repeat="app.todos"
+            name="$item.name"
+            description="$item.description"
+            status="$item.status"
+            onclick="openTodo($item)"
+	></todo-item>
+</todo-app>
+```
+
+### Data and methods
+Any data defined inside the class is available inside the template but not inside the custom components
+you create.
+
+From the example above, the `app` object cannot be accessed inside the `todo-item` template. However, you can access
+the data and methods inside the `todo-item` tag body.
+
+```html
+<!-- index.html-->
+
+<todo-app>
+	<todo-item
+		repeat="app.todos"
+		name="$item.name"
+		description="$item.description"
+		status="$item.status"
+	>
+        <!-- 
+         the todo-item tag has a slot for the button that handles
+         opening the single todo app
+        -->
+        <button onclick="openTodo($item)">open</button>
+    </todo-item>
+</todo-app>
+```
+
+What this means is that, any HTML tag that is placed inside the body of the `todo-app` tag can access the
+ToDoApp class data and methods. Any HTML tag that belongs to other tags template will not. For those, you 
+need to specify data as context.
+
+### Context
+ContextProviderComponent is like any other WebComponent and therefore, it may contain 
+[context data](https://github.com/beforesemicolon/web-component/blob/master/doc/context.md).
+
+This is the only way you can provide data inside the descendents component templates and it is excellent
+for data you want to share deeply for all components.
+
+```js
+class ThemeProvider extends ContextProviderComponent {
+  static initialContext = {
+    theme: {
+      colors: {
+        primary: 'purple', 
+        secondary: '#222', 
+        cta: '#900', 
+        light: '#f2f2f2', 
+        dark: '#111', 
+      },
+    }
+  }
+}
+```
+
+Simply wrap your global data provider using context around the component tag, and it will be available
+deeply inside any component templates.
+
+```html
+<theme-provider>
+    <todo-app>
+        <button 
+            type="button" 
+            attr.style="color: {theme.colors.light}; background: {theme.colors.primary}, true">click me</button>
+    </todo-app>
+</theme-provider>
+```
+
+### Styling
+Styling your context provider component is no different than styling any other WebComponent but because
+it by default it does not use shadow root, you need to prefix every style with the `:host` to make sure
+the style does not affect things outside of its body.
+
+```js
+class TodoApp extends ContextProviderComponent {
+  ...
+  
+  get stylesheet() {
+    return `
+      <style>
+        :host h1 {
+          color: {theme.colors.primary};
+        }
+      </style>
+    `;
+  }
+  
+  get template() {
+    return `
+      <h1>{app.title}</h1>
+      <p>{app.description</p>
+      <slot></slot>
+    `;
+  }
+}
+```
+
+One thing to know is that the [::slotted selector](https://developer.mozilla.org/en-US/docs/Web/CSS/::slotted)
+will not work because the way the ContextProviderComponent handles the slot tags no matter what the mode
+of the component.
+
+#### Recommended next: [Configurations](https://github.com/beforesemicolon/web-component/blob/master/doc/directives.md)

--- a/doc/ContextProviderComponent.md
+++ b/doc/ContextProviderComponent.md
@@ -185,7 +185,7 @@ class TodoApp extends ContextProviderComponent {
     return `
       <style>
         :host h1 {
-          color: {theme.colors.primary};
+          color: [theme.colors.primary];
         }
       </style>
     `;

--- a/doc/WebComponent.md
+++ b/doc/WebComponent.md
@@ -1,4 +1,4 @@
-## Web Component class
+## WebComponent
 The WebComponent class is the only API you need to interact with in order to create your components. 
 That should make things pretty simple to learn.
 

--- a/doc/context.md
+++ b/doc/context.md
@@ -216,4 +216,4 @@ The context is not meant to replace `attributes` and `properties` in any way. It
 - Global data belongs to the `context`.
 - Use context components to manage context.
 
-#### Recommended next: [Directives](https://github.com/beforesemicolon/web-component/blob/master/doc/directives.md)
+#### Recommended next: [ContextProviderComponent](https://github.com/beforesemicolon/web-component/blob/master/doc/ContextProviderComponent.md)

--- a/doc/stylesheet.md
+++ b/doc/stylesheet.md
@@ -1,5 +1,5 @@
 ## Stylesheet
-The stylesheet is a way to define the style for the component.
+The stylesheet getter is a way to define the style for the component.
 
 ```js
 class SubmitButton extends WebComponent {
@@ -48,6 +48,62 @@ The above example style will look like the following the head tag.
 		}
 	</style>
 </head>
+```
+
+### data binding
+You can refer to data inside the stylesheet by using the `[]` syntax. You can only do it for the property values.
+
+This is great for when you want to refer to some theme data or simply want to react to data changes for CSS updates.
+Yes! It will update on data changes. This means that you may not need to define class to pe set or removed
+on data changes to update the style.
+
+Take the following button component as example. It is referring to the `theme` of the app which can be just coming
+from some [context provider component](https://github.com/beforesemicolon/web-component/blob/master/doc/ContextProviderComponent.md), 
+and it is falling back to some other color in case those do not exist.
+
+```js
+class MyButton extends WebComponent {
+  get stylesheet() {
+    return `
+      <style>
+        :host button {
+            color: [theme?.colors?.light || '#fff'];
+            background-color: [theme?.colors?.secondary || '#000'];
+        }
+      </style>
+    `
+  }
+  
+  get template() {
+    return `<button type="button"><slot>click me</slot></button>`;
+  }
+}
+```
+
+Let's say the theme provider component looks something like this:
+
+```js
+class ThemeProvider extends ContextProvider {
+  static initialContext = {
+    theme: {
+      colors: {
+        primary: 'purple',
+        secondary: '#222',
+        cta: '#900',
+        light: '#f2f2f2',
+        dark: '#111',
+      },
+    }
+  }
+}
+```
+
+We can then use the `ThemeProvider` component to provide the theme to the `MyButton` component.
+
+```html
+<theme-provider>
+	<my-button></my-button>
+</theme-provider>
 ```
 
 #### Recommended next: [Template](https://github.com/beforesemicolon/web-component/blob/master/doc/template.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beforesemicolon/web-component",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Web Component Client Framework",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "build:min": "esbuild src/web-component.ts --bundle --minify --sourcemap --target=chrome58 --outfile=dist/web-component.min.js",
-    "build": "tsc --noEmit && rm -rf dist && npm run build:min && tsc",
-    "local": "nodemon --watch src -e ts --exec npm run build"
+    "build:browser": "esbuild src/web-component.ts --bundle --minify --sourcemap --target=chrome58 --outfile=dist/web-component.min.js",
+    "build:browser-local": "esbuild src/web-component.ts --bundle --target=chrome58 --outfile=dist/web-component.min.js",
+    "build": "tsc --noEmit && rm -rf dist && npm run build:browser && tsc",
+    "build:local": "tsc --noEmit && rm -rf dist && npm run build:browser-local && tsc",
+    "local": "nodemon --watch src -e ts --exec npm run build:local"
   },
   "keywords": [
     "web-component",

--- a/src/utils/extract-executable-snippet-from-string.spec.ts
+++ b/src/utils/extract-executable-snippet-from-string.spec.ts
@@ -2,7 +2,7 @@ import {extractExecutableSnippetFromString} from './extract-executable-snippet-f
 
 describe('extractExecutableSnippetFromString', () => {
   
-  it('should extract pair curly braces content', () => {
+  it('should extract pair curly braces content with default start and end symbol', () => {
     [
       ['{item}', 'item'],
       ['{{item}', 'item'],
@@ -21,6 +21,29 @@ describe('extractExecutableSnippetFromString', () => {
         const executable = execs[i];
         expect(res.executable).toEqual(executable);
         expect(res.match).toEqual(`{${executable}}`);
+      })
+    })
+  });
+
+  it('should extract pair curly braces content with provided start and end symbol', () => {
+    [
+      ['[item]', 'item'],
+      ['[[item]', 'item'],
+      ['][item]', 'item'],
+      ['[item]]', 'item'],
+      ['[item][', 'item'],
+      ['[[sample: 12]]', '[sample: 12]'],
+      ['[[sample: 12, x: [text: "super"]]]', '[sample: 12, x: [text: "super"]]'],
+      ['[[sample: 12, x: [text: "super"]]] [sample]', '[sample: 12, x: [text: "super"]]', 'sample'],
+      ['[sample] [test]', 'sample', 'test'],
+      ['[list.push([name: "sample"])] [[sample: 12]] [test]', 'list.push([name: "sample"])', '[sample: 12]', 'test'],
+      ['[sample - test] []', 'sample - test'],
+      ['([my [work]])', 'my [work]'],
+    ].forEach(([str, ...execs]) => {
+      extractExecutableSnippetFromString(str, ['[', ']']).forEach((res, i) => {
+        const executable = execs[i];
+        expect(res.executable).toEqual(executable);
+        expect(res.match).toEqual(`[${executable}]`);
       })
     })
   });

--- a/src/utils/extract-executable-snippet-from-string.ts
+++ b/src/utils/extract-executable-snippet-from-string.ts
@@ -1,6 +1,6 @@
-export function extractExecutableSnippetFromString(str: string) {
+export function extractExecutableSnippetFromString(str: string, [start, end] = ['{', '}']) {
 	const stack = [];
-	const pattern = /[}{]/g;
+	const pattern = new RegExp(`[\\${start}\\${end}]`, 'g');
 	let snippets: Executable[] = [];
 	let match;
 	let startingCurlyIndex: number;
@@ -8,9 +8,9 @@ export function extractExecutableSnippetFromString(str: string) {
 	while ((match = pattern.exec(str)) !== null) {
 		const char = match[0];
 
-		if (char === '{') {
+		if (char === start) {
 			stack.push(match.index);
-		} else if (char === '}' && stack.length) {
+		} else if (char === end && stack.length) {
 			startingCurlyIndex = stack.pop() as number;
 
 			const matchStr = str.slice(startingCurlyIndex + 1, match.index);
@@ -27,7 +27,7 @@ export function extractExecutableSnippetFromString(str: string) {
 				snippets.push({
 					from: startingCurlyIndex,
 					to: match.index,
-					match: `{${matchStr}}`,
+					match: `${start}${matchStr}${end}`,
 					executable: matchStr
 				});
 			}

--- a/src/utils/set-component-properties-from-observed-attributes.ts
+++ b/src/utils/set-component-properties-from-observed-attributes.ts
@@ -3,13 +3,21 @@ import {proxify} from './proxify';
 import boolAttr from './boolean-attributes.json';
 import {directives} from "./directives";
 
-export function setComponentPropertiesFromObservedAttributes(component: HTMLElement, observedAttributes: string[], onUpdate: onUpdateCallback) {
+export function setComponentPropertiesFromObservedAttributes(
+	component: HTMLElement,
+	observedAttributes: string[],
+	onUpdate: onUpdateCallback
+): string[] {
+	const properties: string[] = [];
+
 	observedAttributes.forEach(prop => {
 		prop = prop.trim();
 
 		if (!directives.has(prop) && !(prop.startsWith('data-') || prop === 'class' || prop === 'style')) {
 			let value: string | boolean = component.getAttribute(prop) ?? '';
 			prop = turnKebabToCamelCasing(prop);
+
+			properties.push(prop);
 
 			if (value) {
 				try {
@@ -43,4 +51,6 @@ export function setComponentPropertiesFromObservedAttributes(component: HTMLElem
 			})
 		}
 	})
+
+	return properties;
 }

--- a/src/utils/setup-component-properties-for-auto-update.ts
+++ b/src/utils/setup-component-properties-for-auto-update.ts
@@ -2,7 +2,8 @@ import {turnCamelToKebabCasing} from "./turn-camel-to-kebab-casing";
 import {directives} from "./directives";
 import {proxify} from "./proxify";
 
-export function setupComponentPropertiesForAutoUpdate(component: WebComponent, onUpdate: onUpdateCallback) {
+export function setupComponentPropertiesForAutoUpdate(component: WebComponent, onUpdate: onUpdateCallback): string[] {
+	const properties: string[] = [];
 
 	for (let property of Object.getOwnPropertyNames(component)) {
 		const attr = turnCamelToKebabCasing(property);
@@ -10,6 +11,8 @@ export function setupComponentPropertiesForAutoUpdate(component: WebComponent, o
 		// ignore private properties and $ properties as well as attribute properties
 		if (!directives.has(property) && !/\$|_/.test(property[0]) && !(component.constructor as WebComponentConstructor).observedAttributes.includes(attr)) {
 			let value = component[property];
+
+			properties.push(property);
 
 			value = proxify(property, value, () => {
 				onUpdate(property, value, value);
@@ -32,4 +35,6 @@ export function setupComponentPropertiesForAutoUpdate(component: WebComponent, o
 			})
 		}
 	}
+
+	return properties;
 }

--- a/src/web-component.ts
+++ b/src/web-component.ts
@@ -884,21 +884,21 @@ export class WebComponent extends HTMLElement {
 					break;
 				default:
 					if (attrName) {
-						const kebabProp = turnCamelToKebabCasing(attrName);
 						if (shouldAdd) {
 							if (booleanAttr.hasOwnProperty(attrName)) {
-								node.setAttribute(kebabProp, '');
+								node.setAttribute(attrName, '');
 							} else {
 								const idealVal = val || shouldAdd;
+								const kebabProp = turnCamelToKebabCasing(attrName);
 
-								if ((node as ObjectLiteral)[attrName] !== undefined) {
-									(node as ObjectLiteral)[attrName] = idealVal;
+								if ((node as ObjectLiteral)[kebabProp] !== undefined) {
+									(node as ObjectLiteral)[kebabProp] = idealVal;
 								} else {
-									node.setAttribute(kebabProp, idealVal.toString());
+									node.setAttribute(attrName, idealVal.toString());
 								}
 							}
 						} else {
-							node.removeAttribute(kebabProp);
+							node.removeAttribute(attrName);
 						}
 					}
 			}

--- a/src/web-component.ts
+++ b/src/web-component.ts
@@ -506,11 +506,12 @@ export class WebComponent extends HTMLElement {
 		}
 	}
 
-	private _execString(executable: string, [$item, $key]: any[] = []) {
+	private _execString(executable: string, node: ObjectLiteral) {
 		if (!executable.trim()) {
 			return;
 		}
 
+		const {$item, $key} = node;
 		const keys = this._properties.slice();
 		const ctx = this.$context;
 
@@ -554,7 +555,7 @@ export class WebComponent extends HTMLElement {
 			}
 		}
 
-		let res = this._execString(executable, [$item, $key]);
+		let res = this._execString(executable, node);
 
 		if (res && typeof res === 'object') {
 			try {
@@ -649,11 +650,9 @@ export class WebComponent extends HTMLElement {
 
 	private _handleIfAttribute(node: WebComponent) {
 		const attr = 'if';
-		// @ts-ignore
-		let {$item, $key} = node;
 		let {value, placeholderNode}: DirectiveValue = (node as ObjectLiteral)[attr][0];
 
-		const shouldRender = this._execString(value, [$item, $key]);
+		const shouldRender = this._execString(value, node);
 
 		(node as ObjectLiteral)[attr][0].prevValue = shouldRender
 
@@ -714,7 +713,7 @@ export class WebComponent extends HTMLElement {
 		const attr = 'repeat';
 		const repeatAttr = 'repeat_id';
 		let {value, placeholderNode}: DirectiveValue = (node as ObjectLiteral)[attr][0];
-		let repeatData = this._execString(value);
+		let repeatData = this._execString(value, node);
 		let index = 0;
 
 		if (!(node as ObjectLiteral)[repeatAttr]) {
@@ -814,12 +813,11 @@ export class WebComponent extends HTMLElement {
 
 		(node as ObjectLiteral)[attr].forEach(({value, prop}: DirectiveValue) => {
 			let [attrName, property] = prop.split('.');
-			let {$item, $key} = node as ObjectLiteral;
 			const commaIdx = value.lastIndexOf(',');
 			let val = commaIdx >= 0 ? value.slice(0, commaIdx).trim() : '';
 			const shouldAdd = this._execString(
 				commaIdx >= 0 ? value.slice(commaIdx + 1).trim() : value,
-				[$item, $key]);
+				node);
 
 			if (val) {
 				extractExecutableSnippetFromString(val).forEach((exc) => {


### PR DESCRIPTION
-- features
- Intro to [ContextProviderComponent](https://github.com/beforesemicolon/web-component/blob/master/doc/ContextProviderComponent.md) to properly handle slots and templates in HTML file
- [style data binding](https://github.com/beforesemicolon/web-component/blob/master/doc/stylesheet.md#data-binding). Support for referencing data inside the stylesheet property values;

-- fixes:
- handling boolean attributes with attr directive
- double rendering of slotted nodes

-- other
- internal code improvements improvements
- documents updates
- additional tests